### PR TITLE
slash the difficulty retarget duration

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -80,7 +80,7 @@ public:
         consensus.BIP65Height = 918684; // bab3041e8977e0dc3eeff63fe707b92bde1dd449d8efafb248c27c8264cc311a
         consensus.BIP66Height = 811879; // 7aceee012833fa8952f8835d8b1b3ae233cd6ab08fdb27a771d2bd7bdc491894
         consensus.powLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); 
-        consensus.nPowTargetTimespan = 4 * 60 * 60;
+        consensus.nPowTargetTimespan = 30 * 60;
         consensus.nPowTargetSpacing = 60;
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;


### PR DESCRIPTION
* 4 hrs > 30 min

- This should help the difficulty catch up to big miners much faster
- Additionally, it should fall back down much quicker than previously